### PR TITLE
Add CSP support, both for the luma and hyvä templates.

### DIFF
--- a/view/frontend/templates/critical-css.phtml
+++ b/view/frontend/templates/critical-css.phtml
@@ -7,7 +7,7 @@
 
 use Magento\Framework\View\Element\Template;
 
-/* @var $block Template */
+/** @var Template $block */
 ?>
 
 <!-- Critical CSS for <lite-youtube> element to avoid CLS: https://web.dev/cls/ -->

--- a/view/frontend/templates/hyva/lite-youtube.phtml
+++ b/view/frontend/templates/hyva/lite-youtube.phtml
@@ -5,11 +5,13 @@
  * See LICENSE.md file for details.
  */
 
+use Hyva\Theme\ViewModel\HyvaCsp;
 use Magento\Framework\Escaper;
 use Magento\Framework\View\Element\Template;
 
-/* @var $block Template */
-/* @var $escaper Escaper */
+/** @var Template $block */
+/** @var Escaper $escaper */
+/** @var HyvaCsp $hyvaCsp */
 
 $liteYouTubeCss = $block->getViewFileUrl('MageQuest_LiteYouTube::css/lite-yt-embed.min.css');
 $liteYouTubeJs = $block->getViewFileUrl('MageQuest_LiteYouTube::js/lite-yt-embed.min.js');
@@ -36,3 +38,4 @@ $liteYouTubeJs = $block->getViewFileUrl('MageQuest_LiteYouTube::js/lite-yt-embed
         });
     })();
 </script>
+<?php isset($hyvaCsp) && $hyvaCsp->registerInlineScript() ?>

--- a/view/frontend/templates/lite-youtube.phtml
+++ b/view/frontend/templates/lite-youtube.phtml
@@ -7,15 +7,16 @@
 
 use Magento\Framework\Escaper;
 use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-/* @var $block Template */
-/* @var $escaper Escaper */
+/** @var Template $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 $liteYouTubeCss = $block->getViewFileUrl('MageQuest_LiteYouTube::css/lite-yt-embed.min.css');
 $liteYouTubeJs = $block->getViewFileUrl('MageQuest_LiteYouTube::js/lite-yt-embed.min.js');
-?>
 
-<script>
+$scriptString = <<<scriptStr
     require(['domReady!'], function() {
         'use strict';
 
@@ -25,12 +26,14 @@ $liteYouTubeJs = $block->getViewFileUrl('MageQuest_LiteYouTube::js/lite-yt-embed
 
             link.rel = 'stylesheet';
             link.type = 'text/css';
-            link.href = '<?= $escaper->escapeJs($escaper->escapeUrl($liteYouTubeCss)) ?>';
+            link.href = '{$escaper->escapeJs($escaper->escapeUrl($liteYouTubeCss))}';
             document.head.appendChild(link);
 
             script.type = 'text/javascript';
-            script.src = '<?= $escaper->escapeJs($escaper->escapeUrl($liteYouTubeJs)) ?>';
+            script.src = '{$escaper->escapeJs($escaper->escapeUrl($liteYouTubeJs))}';
             document.head.appendChild(script);
         }
     });
-</script>
+scriptStr;
+?>
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>


### PR DESCRIPTION
Added CSP support both for the Luma and Hyvä templates.
I added the `isset` check around `$hyvaCsp` so the module works on older and newer Hyvä versions.

I also took the liberty of fixing type annotations in the template files:
- it needs two `*`
- the type should be before the variable name

Thanks!